### PR TITLE
Init latlon for world

### DIFF
--- a/buoy_gazebo/worlds/buoy_no_plugins.sdf
+++ b/buoy_gazebo/worlds/buoy_no_plugins.sdf
@@ -2,6 +2,14 @@
 <sdf version="1.6">
   <world name="buoy_no_plugins">
 
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>36.743850</latitude_deg>
+      <longitude_deg>-121.876233</longitude_deg>
+      <elevation>0.0</elevation>
+    </spherical_coordinates>
+
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
       <pose>0 0 10 0 0 0</pose>

--- a/buoy_gazebo/worlds/buoy_playground.sdf
+++ b/buoy_gazebo/worlds/buoy_playground.sdf
@@ -1,6 +1,15 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
   <world name="playground">
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>36.743850</latitude_deg>
+      <longitude_deg>-121.876233</longitude_deg>
+      <elevation>0.0</elevation>
+    </spherical_coordinates>
+
     <physics name="1ms" type="ignored">
       <real_time_factor>0</real_time_factor>
       <max_step_size>0.001</max_step_size>

--- a/buoy_gazebo/worlds/electrohydraulicPTO.sdf
+++ b/buoy_gazebo/worlds/electrohydraulicPTO.sdf
@@ -2,6 +2,14 @@
 <sdf version="1.8">
     <world name="mbari_wec_world">
 
+        <spherical_coordinates>
+          <surface_model>EARTH_WGS84</surface_model>
+          <world_frame_orientation>ENU</world_frame_orientation>
+          <latitude_deg>36.743850</latitude_deg>
+          <longitude_deg>-121.876233</longitude_deg>
+          <elevation>0.0</elevation>
+        </spherical_coordinates>
+
         <physics name="1ms" type="ignored">
             <max_step_size>.001</max_step_size>
             <real_time_factor>1.0</real_time_factor>

--- a/buoy_gazebo/worlds/mbari_wec.sdf.em
+++ b/buoy_gazebo/worlds/mbari_wec.sdf.em
@@ -13,9 +13,23 @@ try:
 except NameError:
     physics_rtf = 1.0  # not defined so default
 
+# Check if lat_lon was passed in via empy
+try:
+    lat_lon
+except NameError:
+    lat_lon = [36.743850, -121.876233]  # not defined so default
+
 }@
 <sdf version="1.8">
   <world name="mbari_wec_world">
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>@(lat_lon[0])</latitude_deg>
+      <longitude_deg>@(lat_lon[1])</longitude_deg>
+      <elevation>0.0</elevation>
+    </spherical_coordinates>
 
     <physics name="step" type="ignored">
       <max_step_size>@(physics_step)</max_step_size>

--- a/buoy_gazebo/worlds/mbari_wec_sinusoidal_piston.sdf
+++ b/buoy_gazebo/worlds/mbari_wec_sinusoidal_piston.sdf
@@ -2,6 +2,14 @@
 <sdf version="1.8">
   <world name="sinusoidal_piston">
 
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>36.743850</latitude_deg>
+      <longitude_deg>-121.876233</longitude_deg>
+      <elevation>0.0</elevation>
+    </spherical_coordinates>
+
     <physics name="1ms" type="ignored">
       <max_step_size>.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>

--- a/buoy_gazebo/worlds/pneumatic_spring.sdf
+++ b/buoy_gazebo/worlds/pneumatic_spring.sdf
@@ -2,6 +2,14 @@
 <sdf version="1.8">
     <world name="mbari_wec_world">
 
+        <spherical_coordinates>
+          <surface_model>EARTH_WGS84</surface_model>
+          <world_frame_orientation>ENU</world_frame_orientation>
+          <latitude_deg>36.743850</latitude_deg>
+          <longitude_deg>-121.876233</longitude_deg>
+          <elevation>0.0</elevation>
+        </spherical_coordinates>
+
         <physics name="1ms" type="ignored">
             <max_step_size>.0005</max_step_size>
             <real_time_factor>1.0</real_time_factor>

--- a/buoy_gazebo/worlds/test_viscous_drag.sdf
+++ b/buoy_gazebo/worlds/test_viscous_drag.sdf
@@ -2,6 +2,14 @@
 <sdf version="1.8">
   <world name="test_world">
 
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>36.743850</latitude_deg>
+      <longitude_deg>-121.876233</longitude_deg>
+      <elevation>0.0</elevation>
+    </spherical_coordinates>
+
     <physics name="1ms" type="ignored">
       <max_step_size>.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>

--- a/buoy_tests/worlds/TestMachine.sdf
+++ b/buoy_tests/worlds/TestMachine.sdf
@@ -1,5 +1,14 @@
 <sdf version="1.8">
   <world name="PTO_TestBench">
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>36.743850</latitude_deg>
+      <longitude_deg>-121.876233</longitude_deg>
+      <elevation>0.0</elevation>
+    </spherical_coordinates>
+
     <physics name="1ms" type="ignored">
         <max_step_size>.01</max_step_size>
         <real_time_factor>10000.0</real_time_factor>

--- a/buoy_tests/worlds/singlefloatingbody_heave.sdf
+++ b/buoy_tests/worlds/singlefloatingbody_heave.sdf
@@ -2,6 +2,14 @@
 <sdf version="1.8">
   <world name="single_floating_body_world">
 
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>36.743850</latitude_deg>
+      <longitude_deg>-121.876233</longitude_deg>
+      <elevation>0.0</elevation>
+    </spherical_coordinates>
+
     <physics name="1ms" type="ignored">
       <max_step_size>0.01</max_step_size>
       <real_time_factor>1.0</real_time_factor>

--- a/buoy_tests/worlds/singlefloatingbody_pitch.sdf
+++ b/buoy_tests/worlds/singlefloatingbody_pitch.sdf
@@ -1,6 +1,14 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
-  <world name="single_floating_body_ world">
+  <world name="single_floating_body_world">
+
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>36.743850</latitude_deg>
+      <longitude_deg>-121.876233</longitude_deg>
+      <elevation>0.0</elevation>
+    </spherical_coordinates>
 
     <physics name="1ms" type="ignored">
       <max_step_size>0.01</max_step_size>


### PR DESCRIPTION
This warning was being spammed:
```
[Wrn] [Magnetometer.cc:433] Failed to update NavSat sensor enity [84]. Spherical coordinates not set.
```

This PR adds a `spherical_coordinates` to the main world file to init world origin and the warning goes away.