### PR TITLE
Add launch param overrides

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -62,8 +62,8 @@ colcon build --packages-up-to buoy_tests --event-handlers console_direct+
 source $COLCON_WS/install/setup.bash
 
 # Test all buoy packages
-#colcon test --packages-select-regex=buoy --packages-skip=buoy_msgs --event-handlers console_direct+ --retest-until-pass 10
-#colcon test-result
+colcon test --packages-select-regex=buoy --packages-skip=buoy_msgs --event-handlers console_direct+ --retest-until-pass 10
+colcon test-result
 
 # Debug specific test
-launch_test $COLCON_WS/install/buoy_tests/share/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
+# launch_test $COLCON_WS/install/buoy_tests/share/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -62,5 +62,8 @@ colcon build --packages-up-to buoy_tests --event-handlers console_direct+
 source $COLCON_WS/install/setup.bash
 
 # Test all buoy packages
-colcon test --packages-select-regex=buoy --packages-skip=buoy_msgs --event-handlers console_direct+ --retest-until-pass 10
-colcon test-result
+#colcon test --packages-select-regex=buoy --packages-skip=buoy_msgs --event-handlers console_direct+ --retest-until-pass 10
+#colcon test-result
+
+# Debug specific test
+launch_test $COLCON_WS/install/buoy_tests/share/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py

--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -84,7 +84,7 @@ else:
     inc_wave_spectrum = lambda : '<!-- No Waves -->'
 
 ############################
-# Mean Piston Position
+# Piston Position
 ############################
 
 # Would like to specify piston mean position and set all other
@@ -94,12 +94,19 @@ else:
 # that brings the equilibrium to the desired mean piston position.
 # Recompute pressure and volume based on Ideal Gas Law.
 
+# Check if initial piston position (m) was passed in via empy
+try:
+    initial_piston_position
+except NameError:
+    initial_piston_position = 0.7  # m, default;
+                                   # measured from fully retracted (same as range_finder)
+
 # Check if x_mean_pos (m, mean piston position) was passed in via empy
-# with the current parameters, the mean position settles around 1.21m
 try:
     x_mean_pos
 except NameError:
     x_mean_pos = 0.7  # m, default; measured from fully retracted (same as range_finder)
+
 
 import math
 import scipy.optimize as spo
@@ -195,6 +202,7 @@ if not ignore_piston_mean_pos:
       <JointName>HydraulicRam</JointName>
       <chamber>upper_polytropic</chamber>
       <is_upper>true</is_upper>
+      <initial_piston_position>@(initial_piston_position)</initial_piston_position>
       <!-- measure of valve opening cross-section and duration (meter-seconds) -->
       <valve_absement>7.77e-6</valve_absement>
       <pump_absement>4.3e-8</pump_absement>

--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -43,15 +43,15 @@ def bretschneider_spectrum(Hs=2.0, Tp=13.0):
       <Tp>{Tp}</Tp>
 ''')
 
-def custom_spectrum(w=None, Szz=None):
+def custom_spectrum(f=None, Szz=None):
     ''' Prints the Custom <IncWaveSpectrumType> block for the IncidentWave plugin. '''
-    if w is None:
-        w = [0.0, 0.2, 0.4, 0.6, 2.0]
+    if f is None:
+        f = [0.0, 0.2, 0.4, 0.6, 2.0]
     if Szz is None:
         Szz = [0.0, 0.4, 1.0, 1.0, 0.0]
     coefs = \
-        ('\n' + 6*' ').join([f'<w{idx}>{wn}</w{idx}> <Szz{idx}>{Szzn}</Szz{idx}>'
-            for idx, (wn, Szzn) in enumerate(zip(w, Szz))])
+        ('\n' + 6*' ').join([f'<f{idx}>{fn}</f{idx}> <Szz{idx}>{Szzn}</Szz{idx}>'
+            for idx, (fn, Szzn) in enumerate(zip(f, Szz))])
     print(f'''
       <IncWaveSpectrumType>Custom</IncWaveSpectrumType>
       {coefs}
@@ -77,7 +77,7 @@ elif 'Bretschneider' in inc_wave_spectrum_type:
         inc_wave_spectrum = bretschneider_spectrum  # default
 elif 'Custom' in inc_wave_spectrum_type:
     try:
-        inc_wave_spectrum = partial(custom_spectrum, w, Szz)
+        inc_wave_spectrum = partial(custom_spectrum, f, Szz)
     except NameError:
         inc_wave_spectrum = custom_spectrum  # default
 else:

--- a/buoy_description/models/mbari_wec_base/model.sdf.em
+++ b/buoy_description/models/mbari_wec_base/model.sdf.em
@@ -96,10 +96,10 @@ pto_inner_radius = tether_radius + pto_gap
 pto_scale = pto_inner_radius / pto_stl_inner_radius
 
 # PTO Buoyancy (specify desired COB, computes location of extra volume above .stl collision mesh)
-pto_disp = .205  # m^3  (Specified)
-pto_cob = -3  # z-position, on centerline (Specified)
-stl_disp = .160443 # m^3  Specific to .stl file
-stl_cob = 0 # z-position, on centerline. Buoyancy plugin uses collisioin pose origin, not center of mesh volume
+pto_disp = 0.205  # m^3  (Specified)
+pto_cob = -3.0  # z-position, on centerline (Specified)
+stl_disp = 0.160443 # m^3  Specific to .stl file
+stl_cob = 0.0 # z-position, on centerline. Buoyancy plugin uses collisioin pose origin, not center of mesh volume
 buoyancy_disp = pto_disp - stl_disp
 buoyancy_cob = (pto_cob*pto_disp - stl_cob*stl_disp)/buoyancy_disp
 buoyancy_radius = ((3*buoyancy_disp)/(4*math.pi))**(1/3)
@@ -574,7 +574,6 @@ buoyancy_radius = ((3*buoyancy_disp)/(4*math.pi))**(1/3)
       <axis>
         <limit>
           <lower>0.0</lower>
-          <!-- TODO(chapulina) Check why it's only going up to ~1.16-->
           <upper>2.03</upper>
           <effort>1e6</effort>
         </limit>

--- a/buoy_gazebo/launch/mbari_wec.launch.py
+++ b/buoy_gazebo/launch/mbari_wec.launch.py
@@ -64,11 +64,10 @@ def regenerate_models(context, *args, **kwargs):
                     'battery_emf',
                     'x_mean_pos']
     all_params = supported_mbari_wec_base_params \
-                 + supported_mbari_wec_world_params \
-                 + supported_mbari_wec_model_params
+        + supported_mbari_wec_world_params \
+        + supported_mbari_wec_model_params
     override_params = {param: LaunchConfiguration(param).perform(context) for param in all_params}
     override_params = {k: v for k, v in override_params.items() if v != 'None'}
-    # override_params = {k: (float(v) if k in float_params else v) for k, v in override_params.items()}
     print('Sim Parameter Overrides:', override_params)
 
     # Find packages
@@ -95,25 +94,23 @@ def regenerate_models(context, *args, **kwargs):
     for wec_base_param in supported_mbari_wec_base_params:
         if wec_base_param in override_params:
             mbari_wec_base_params.extend(['-D',
-                                          f'{wec_base_param}' \
-                                          f" = '{override_params[wec_base_param]}'"])
+                                          f'{wec_base_param}'
+                                          + f" = '{override_params[wec_base_param]}'"])
 
     mbari_wec_base_params.extend(['-o', base_sdf_file,
                                   empy_base_sdf_file])
     empy(mbari_wec_base_params)
-    print('base params done')
 
     # fill mbari_wec world template with params
     mbari_wec_world_params = []
     for world_param in supported_mbari_wec_world_params:
         if world_param in override_params:
             mbari_wec_world_params.extend(['-D',
-                                           f'{world_param}' \
+                                           f'{world_param}'
                                            + f' = {float(override_params[world_param])}'])
     mbari_wec_world_params.extend(['-o', world_file,
                                    empy_world_file])
     empy(mbari_wec_world_params)
-    print('world params done')
 
     # fill mbari_wec model template with params
     mbari_wec_model_params = []
@@ -121,24 +118,19 @@ def regenerate_models(context, *args, **kwargs):
         if world_param in override_params:
             print(f'{world_param = }\n{override_params[world_param] = }')
             if 'inc_wave_spectrum_type' in override_params[world_param]:
-                print('here inc wave')
                 inc_wave_spectrum = override_params[world_param].split(';')
-                print(f'{inc_wave_spectrum = }')
                 no_params = len(inc_wave_spectrum) > 1
-                print(f'{no_params = } : {len(inc_wave_spectrum) = }')
                 inc_wave_spectrum_type = inc_wave_spectrum[0].split(':')
-                print(f'{inc_wave_spectrum_type = }')
                 no_type = \
                     len(inc_wave_spectrum_type) < 2 \
                     or 'None' in inc_wave_spectrum_type[1]
-                print(f'{no_type = }')
                 if len(inc_wave_spectrum_type) == 2:
                     mbari_wec_model_params.extend(['-D',
-                                                   f'{inc_wave_spectrum_type[0]} = ' \
+                                                   f'{inc_wave_spectrum_type[0]} = '
                                                    + f"'{inc_wave_spectrum_type[1]}'"])
                 else:
                     mbari_wec_model_params.extend(['-D',
-                                                   f'{inc_wave_spectrum_type[0]} =' \
+                                                   f'{inc_wave_spectrum_type[0]} ='
                                                    + "''"])
                 if not no_params and not no_type:
                     for spectrum_param in inc_wave_spectrum[1:]:
@@ -148,31 +140,25 @@ def regenerate_models(context, *args, **kwargs):
                         elif len(spectrum_param) == 2:
                             name, value = spectrum_param[0], float(spectrum_param[1])
                             mbari_wec_model_params.extend(['-D',
-                                                           f'{name} = ' \
+                                                           f'{name} = '
                                                            + f'{value}'])
                         else:  # Custom Spectrum
                             name, values = spectrum_param[0], spectrum_param[1:]
                             values = [float(v) for v in values]
-                            print(f'{name = } : {values = }')
                             values_str_arr = ','.join([str(v) for v in values])
                             mbari_wec_model_params.extend(['-D',
-                                                           f'{name} = ' \
+                                                           f'{name} = '
                                                            + f'[{values_str_arr}]'])
             else:
-                print('here no inc wave')
                 mbari_wec_model_params.extend(['-D',
-                                               f'{world_param}' \
-                                               + (f' = {float(override_params[world_param])}' \
-                                                      if world_param in float_params else \
+                                               f'{world_param}'
+                                               + (f' = {float(override_params[world_param])}'
+                                                  if world_param in float_params else
                                                   f" = '{override_params[world_param]}'")
                                                ])
     mbari_wec_model_params.extend(['-o', sdf_file,
                                    empy_sdf_file])
-
-    print(f'{mbari_wec_model_params}')
-
     empy(mbari_wec_model_params)
-    print('model params done')
 
     return args
 
@@ -249,7 +235,7 @@ def generate_launch_description():
                         'battery_soc': 'initial battery state of charge as pct (0-1)',
                         'battery_emf': 'initial battery emf in Volts',
                         'x_mean_pos': 'desired mean piston position in meters',
-                        'inc_wave_spectrum': 'incident wave spectrum defined as' \
+                        'inc_wave_spectrum': 'incident wave spectrum defined as'
                                              + 'type;p1:v1:v2;p2:v1:v2'}
     supported_params_args = []
     for param in supported_params:

--- a/buoy_gazebo/launch/mbari_wec.launch.py
+++ b/buoy_gazebo/launch/mbari_wec.launch.py
@@ -40,7 +40,7 @@ def regenerate_models(context, *args, **kwargs):
         launch.actions.OpaqueFunction(function=regenerate_models,
                                       args=dependent_nodes)
 
-    Will grab overriden parameters from launch arguments via context object
+    Will grab overridden parameters from launch arguments via context object
     """
     regenerate_models = LaunchConfiguration('regenerate_models').perform(context)
     if regenerate_models == 'false':

--- a/buoy_gazebo/launch/mbari_wec.launch.py
+++ b/buoy_gazebo/launch/mbari_wec.launch.py
@@ -37,12 +37,10 @@ def regenerate_models(context, *args, **kwargs):
                            bridge,
                            robot_state_publisher,
                            rviz]
-        override_params = dict(door_state='open',
-                               inc_wave_spectrum=\
-                                   'inc_wave_spectrum_type:MonoChromatic;A:1.0;T:12.0')
         launch.actions.OpaqueFunction(function=regenerate_models,
-                                      args=dependent_nodes,
-                                      kwargs=override_params)
+                                      args=dependent_nodes)
+
+    Will grab overriden parameters from launch arguments via context object
     """
     regenerate_models = LaunchConfiguration('regenerate_models').perform(context)
     if regenerate_models == 'false':

--- a/buoy_gazebo/scripts/example_sim_params.yaml
+++ b/buoy_gazebo/scripts/example_sim_params.yaml
@@ -1,7 +1,7 @@
 #
 # Batch-Specific Scalar Parameters
 #
-seed: 42
+seed: 42  # Set `seed: 0` to have different seed per run
 duration: 5
 physics_rtf: 11
 enable_gui: False
@@ -26,8 +26,8 @@ IncidentWaveSpectrumType:
       # May omit Hs & Tp to use default values
       Hs: 3.0
       Tp: 14.0
-  # Multiple Custom Spectra must be listed individually (w & Szz are already vectors of same size)
+  # Multiple Custom Spectra must be listed individually (f & Szz are already vectors of same size)
   - Custom:
-      # May omit w & Szz to use default values
-      w: [0.0, 0.2, 0.4, 0.6, 2.0]
+      # May omit f & Szz to use default values
+      f: [0.0, 0.03, 0.06, 0.09, 0.3]
       Szz: [0.0, 0.4, 1.0, 1.0, 0.0]

--- a/buoy_gazebo/scripts/mbari_wec_batch
+++ b/buoy_gazebo/scripts/mbari_wec_batch
@@ -508,10 +508,10 @@ def generate_simulations(sim_params_yaml):
         gzsim_result = 0
         for info in [proc_info[item] for item in procs]:
             gzsim_result = info.returncode
-        if gzsim_result != 0:
-            node.get_logger().error(f'Simulation run [{idx}] was not successful: ' +
-                                    f'gz-sim return code [{gzsim_result}]')
-            result = gzsim_result
+            if gzsim_result != 0:
+                node.get_logger().error(f'Simulation run [{idx}] was not successful: ' +
+                                        f'gz-sim return code [{gzsim_result}]')
+                result = gzsim_result
 
         # Write to log
         with open(os.path.join(batch_results_dir, 'batch_runs.log'), 'a') as fd:

--- a/buoy_gazebo/scripts/mbari_wec_batch
+++ b/buoy_gazebo/scripts/mbari_wec_batch
@@ -554,7 +554,7 @@ def generate_simulations(sim_params_yaml):
                             # kill just process
                             kill_proc = 'ps x -o "%p %c"' \
                                         + f' | grep {proc}' \
-                                        + ' | cut -d " " -f 2' \
+                                        + " | awk '{ print $1 }'" \
                                         + ' | xargs -I{} kill -9 {}'
 
                             output = subprocess.run(kill_proc, shell=True, check=True)

--- a/buoy_gazebo/scripts/mbari_wec_batch
+++ b/buoy_gazebo/scripts/mbari_wec_batch
@@ -21,6 +21,7 @@ import yaml
 
 import os
 import shutil
+import subprocess
 import sys
 import time
 
@@ -30,7 +31,7 @@ from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit
+from launch.event_handlers import OnProcessExit, OnProcessStart
 
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
@@ -47,7 +48,7 @@ DEFAULT_PHYSICS_MAX_STEP_SIZE = 0.001  # seconds
 class MonoChromatic(object):
     def __init__(self, A, T):
         self.A, self.T = A, T
-        self.name = "MonoChromatic"
+        self.name = 'MonoChromatic'
 
     def __str__(self):
         if self.A is not None:
@@ -59,7 +60,7 @@ class MonoChromatic(object):
 class Bretschneider(object):
     def __init__(self, Hs, Tp):
         self.Hs, self.Tp = Hs, Tp
-        self.name = "Bretschneider"
+        self.name = 'Bretschneider'
 
     def __str__(self):
         if self.Hs is not None:
@@ -71,7 +72,7 @@ class Bretschneider(object):
 class Custom(object):
     def __init__(self, f, Szz):
         self.f, self.Szz = f, Szz
-        self.name = "Custom"
+        self.name = 'Custom'
 
     def __str__(self):
         if self.f is not None:
@@ -158,6 +159,7 @@ def generate_simulations(sim_params_yaml):
     # door state ('open', 'closed')
     if 'door_state' in sim_params:
         door_state = sim_params['door_state']
+        door_state = np.atleast_1d(door_state)
         if any(['open' not in ds and 'closed' not in ds for ds in door_state]):
             node.get_logger().error(
                 "sim_params_yaml: all door_state parameters must be either 'open' or 'closed'"
@@ -468,8 +470,9 @@ def generate_simulations(sim_params_yaml):
         run_results_dir = f'results_run_{idx}_{start_time}'
         os.makedirs(os.path.join(batch_results_dir, run_results_dir))
 
-        # get return codes from processes
-        proc_info = ActiveProcInfoHandler()
+        # get info from processes
+        proc_start_info = ActiveProcInfoHandler()
+        proc_exit_info = ActiveProcInfoHandler()
 
         # python workaround for 'ln -sf'
         os.symlink(os.path.join(run_results_dir, rosbag2_dir),
@@ -497,11 +500,25 @@ def generate_simulations(sim_params_yaml):
                 output='screen'
             )
 
+            def capture_start_pids(info_, unused):
+                proc_start_info.append(info_)
+                start_procs = resolveProcesses(proc_start_info, process='ruby $(which gz) sim')
+                for info in [proc_start_info[item] for item in start_procs]:
+                    print(f'{info.pid}')
+                    print(f'{info.cmd}')
+                    import subprocess
+                    output = subprocess.run(['ps', 'h', '--ppid', f'{info.pid}', '-o', 'pid'])
+                    print(f'{output.stdout}')
+                    print(f'{output.stderr}')
+
             return LaunchDescription([
                 rosbag2,
                 mbari_wec,
+                RegisterEventHandler(  # get info from processes
+                    OnProcessStart(on_start=lambda info, unused: proc_start_info.append(info))
+                ),
                 RegisterEventHandler(  # get return codes from processes
-                    OnProcessExit(on_exit=lambda info, unused: proc_info.append(info))
+                    OnProcessExit(on_exit=lambda info, unused: proc_exit_info.append(info))
                 ),
             ])
 
@@ -515,14 +532,33 @@ def generate_simulations(sim_params_yaml):
                                     f'batch launch return code [{result}]')
 
         # get return codes from processes
-        procs = resolveProcesses(proc_info, process='ruby $(which gz) sim')
+        procs = resolveProcesses(proc_exit_info, process='ruby $(which gz) sim')
         gzsim_result = 0
-        for info in [proc_info[item] for item in procs]:
+        for info in [proc_exit_info[item] for item in procs]:
             gzsim_result = info.returncode
             if gzsim_result != 0:
                 node.get_logger().error(f'Simulation run [{idx}] was not successful: ' +
                                         f'gz-sim return code [{gzsim_result}]')
                 result = gzsim_result
+                if info.returncode < -2:
+                    node.get_logger().error(f'gz sim process may still be running...')
+                    start_procs = resolveProcesses(proc_start_info, process='ruby $(which gz) sim')
+                    for info in [proc_start_info[item] for item in start_procs]:
+                        for proc in ['ruby', 'sim_pblog']:
+                            # kill whole process tree
+                            # kill_proc = 'ps x -o "%r %c"' \
+                            #             + f' | grep {proc}' \
+                            #             + ' | cut -d " " -f 2' \
+                            #             + ' | xargs -I{} kill -9 -- -{}'
+
+                            # kill just process
+                            kill_proc = 'ps x -o "%p %c"' \
+                                        + f' | grep {proc}' \
+                                        + ' | cut -d " " -f 2' \
+                                        + ' | xargs -I{} kill -9 {}'
+
+                            output = subprocess.run(kill_proc, shell=True, check=True)
+                            print(f'{output.args}')
 
         # Write to log
         with open(os.path.join(batch_results_dir, 'batch_runs.log'), 'a') as fd:

--- a/buoy_gazebo/scripts/mbari_wec_batch
+++ b/buoy_gazebo/scripts/mbari_wec_batch
@@ -129,9 +129,9 @@ def generate_simulations(sim_params_yaml):
     # seed (random seed for incident waves plugin)
     try:
         if 'seed' in sim_params:
-            seed = int(sim_params['seed'])
+            seed_ = int(sim_params['seed'])
         else:
-            seed = None
+            seed_ = None
             node.get_logger().warn('sim_params_yaml: optional seed parameter not specified')
     except TypeError:
         node.get_logger().error('sim_params_yaml: seed parameter' +
@@ -345,7 +345,7 @@ def generate_simulations(sim_params_yaml):
                             ', BatteryState, MeanPistonPosition' +
                             ', IncWaveSpectrumType;IncWaveSpectrumParams')
     [node.get_logger().debug(f'{print_optional(ps)}, {print_optional(physics_rtf)}' +
-                             f', {print_optional(seed)}, {duration}, {ds}, {sf}' +
+                             f', {print_optional(seed_)}, {duration}, {ds}, {sf}' +
                              f', {print_optional(bs)}' +
                              f', {print_optional(mpp)}' +
                              f', {print_optional(iw)}')
@@ -378,7 +378,9 @@ def generate_simulations(sim_params_yaml):
     world_file = os.path.join(pkg_buoy_gazebo, 'worlds', 'mbari_wec_batch.sdf')
 
     # Start batch runs
+    rng = np.random.default_rng()
     for idx, (ps, ds, sf, bs, mpp, iw) in enumerate(batch_params):
+        seed = rng.integers(2**32-1) if seed_==0 else seed_
         node.get_logger().info(f'\n\nSim run [{idx}] for {duration} seconds:' +
                                f" door state='{ds}', scale factor={sf}" +
                                f", battery state={bs if bs is not None else 'None'}" +

--- a/buoy_gazebo/scripts/mbari_wec_batch
+++ b/buoy_gazebo/scripts/mbari_wec_batch
@@ -225,7 +225,10 @@ def generate_simulations(sim_params_yaml):
         incident_waves = []
         for inc_wave_spectrum_type in inc_wave_spectrum_types:
             if 'MonoChromatic' in inc_wave_spectrum_type:
-                monochromatic_spectrum = inc_wave_spectrum_type['MonoChromatic']
+                try:
+                    monochromatic_spectrum = inc_wave_spectrum_type['MonoChromatic']
+                except TypeError:  # just default params
+                    monochromatic_spectrum = {}
                 if 'A' in monochromatic_spectrum:
                     A = np.array(monochromatic_spectrum['A'], dtype=float)
                     A = np.atleast_1d(A)
@@ -250,7 +253,10 @@ def generate_simulations(sim_params_yaml):
                     sys.exit(-1)
                 incident_waves.extend([MonoChromatic(a, t) for a, t in zip(A, T)])
             elif 'Bretschneider' in inc_wave_spectrum_type:
-                bretschneider_spectrum = inc_wave_spectrum_type['Bretschneider']
+                try:
+                    bretschneider_spectrum = inc_wave_spectrum_type['Bretschneider']
+                except TypeError:  # just default params
+                    bretschneider_spectrum = {}
                 if 'Hs' in bretschneider_spectrum:
                     Hs = np.array(bretschneider_spectrum['Hs'], dtype=float)
                     Hs = np.atleast_1d(Hs)
@@ -275,7 +281,10 @@ def generate_simulations(sim_params_yaml):
                     sys.exit(-1)
                 incident_waves.extend([Bretschneider(hs, tp) for hs, tp in zip(Hs, Tp)])
             elif 'Custom' in inc_wave_spectrum_type:
-                custom_spectrum = inc_wave_spectrum_type['Custom']
+                try:
+                    custom_spectrum = inc_wave_spectrum_type['Custom']
+                except TypeError:  # just default params
+                    custom_spectrum = {}
                 if 'w' in custom_spectrum:
                     w = np.array(custom_spectrum['w'], dtype=float)
                     w = np.atleast_1d(w)

--- a/buoy_gazebo/scripts/mbari_wec_batch
+++ b/buoy_gazebo/scripts/mbari_wec_batch
@@ -29,7 +29,13 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_testing.proc_info_handler import ActiveProcInfoHandler
+from launch_testing.util import resolveProcesses
 
 import rclpy
 from rclpy.node import Node
@@ -462,6 +468,7 @@ def generate_simulations(sim_params_yaml):
         # TODO(anyone) also path for pblog when ready
         os.makedirs(os.path.join(batch_results_dir, run_results_dir))
 
+        proc_info = ActiveProcInfoHandler()
         def generate_launch_description():
             mbari_wec = IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
@@ -482,16 +489,30 @@ def generate_simulations(sim_params_yaml):
 
             return LaunchDescription([
                 rosbag2,
-                mbari_wec
+                mbari_wec,
+                RegisterEventHandler(
+                    OnProcessExit(on_exit=lambda info, unused: proc_info.append(info))
+                ),
             ])
 
         # Launch sim instance
         ls = LaunchService()
         ls.include_launch_description(generate_launch_description())
         result = ls.run()
-        if result:
+
+        if result != 0:
             node.get_logger().error(f'Simulation run [{idx}] was not successful: ' +
-                                    f'return code [{result}]')
+                                    f'batch launch return code [{result}]')
+
+        procs = resolveProcesses(proc_info, process='ruby $(which gz) sim')
+        gzsim_result = 0
+        for info in [proc_info[item] for item in procs]:
+            gzsim_result = info.returncode
+        if gzsim_result != 0:
+            node.get_logger().error(f'Simulation run [{idx}] was not successful: ' +
+                                    f'gz-sim return code [{gzsim_result}]')
+            result = gzsim_result
+
         # Write to log
         with open(os.path.join(batch_results_dir, 'batch_runs.log'), 'a') as fd:
             fd.write(f'{idx}, {result}, {start_time}' +

--- a/buoy_gazebo/scripts/mbari_wec_batch
+++ b/buoy_gazebo/scripts/mbari_wec_batch
@@ -63,17 +63,17 @@ class Bretschneider(object):
 
 
 class Custom(object):
-    def __init__(self, w, Szz):
-        self.w, self.Szz = w, Szz
+    def __init__(self, f, Szz):
+        self.f, self.Szz = f, Szz
         self.name = "Custom"
 
     def __str__(self):
-        if self.w is not None:
+        if self.f is not None:
             return f'{self.name};' + \
-                   f'w:{":".join([str(w) for w in self.w])};' + \
+                   f'f:{":".join([str(f) for f in self.f])};' + \
                    f'Szz:{":".join([str(Szz) for Szz in self.Szz])}'
         else:
-            return f'{self.name};w:defaults;Szz:defaults'
+            return f'{self.name};f:defaults;Szz:defaults'
 
 
 def generate_simulations(sim_params_yaml):
@@ -84,7 +84,7 @@ def generate_simulations(sim_params_yaml):
     with open(sim_params_yaml, 'r') as fd:
         sim_params = yaml.load(fd, Loader=yaml.CLoader)
 
-    print_optional = lambda param: str(param) if param is not None else ""  # noqa: E731
+    print_optional = lambda param: str(param) if param is not None else ''  # noqa: E731
 
     # Grab params from yaml
     # physics time step (seconds)
@@ -285,30 +285,30 @@ def generate_simulations(sim_params_yaml):
                     custom_spectrum = inc_wave_spectrum_type['Custom']
                 except TypeError:  # just default params
                     custom_spectrum = {}
-                if 'w' in custom_spectrum:
-                    w = np.array(custom_spectrum['w'], dtype=float)
-                    w = np.atleast_1d(w)
+                if 'f' in custom_spectrum:
+                    f = np.array(custom_spectrum['f'], dtype=float)
+                    f = np.atleast_1d(f)
                 else:
-                    w = None
+                    f = None
                 if 'Szz' in custom_spectrum:
                     Szz = np.array(custom_spectrum['Szz'], dtype=float)
                     Szz = np.atleast_1d(Szz)
                 else:
                     Szz = None
 
-                if (w is None) ^ (Szz is None):
+                if (f is None) ^ (Szz is None):
                     node.get_logger().error(
-                        'sim_params_yaml: Custom: w or Szz unspecified.' +
+                        'sim_params_yaml: Custom: f or Szz unspecified.' +
                         ' Please specify both or neither'
                     )
                     sys.exit(-1)
-                if w is not None and Szz is not None:
-                    if w.shape != Szz.shape:
+                if f is not None and Szz is not None:
+                    if f.shape != Szz.shape:
                         node.get_logger().error(
-                            'sim_params_yaml: Custom: w.shape != Szz.shape'
+                            'sim_params_yaml: Custom: f.shape != Szz.shape'
                         )
                         sys.exit(-1)
-                incident_waves.append(Custom(w, Szz))
+                incident_waves.append(Custom(f, Szz))
             else:
                 node.get_logger().error(
                     f'sim_params_yaml: IncWaveSpectrumType [{inc_wave_spectrum_type}]' +
@@ -434,8 +434,8 @@ def generate_simulations(sim_params_yaml):
                     mbari_wec_model_params.extend(['-D', f'Hs = {iw.Hs}'])
                     mbari_wec_model_params.extend(['-D', f'Tp = {iw.Tp}'])
             if 'Custom' in iw.name:
-                if iw.w is not None:
-                    mbari_wec_model_params.extend(['-D', f'w = {iw.w.tolist()}'])
+                if iw.f is not None:
+                    mbari_wec_model_params.extend(['-D', f'f = {iw.f.tolist()}'])
                     mbari_wec_model_params.extend(['-D', f'Szz = {iw.Szz.tolist()}'])
         mbari_wec_model_params.extend(['-o', sdf_file,
                                        empy_sdf_file])

--- a/buoy_gazebo/src/IncidentWaves/IncidentWaves.cpp
+++ b/buoy_gazebo/src/IncidentWaves/IncidentWaves.cpp
@@ -104,22 +104,22 @@ void IncidentWaves::Configure(
 
   if (!SpectrumType.compare("Custom")) {
     gzwarn << "SpectrumType " << SpectrumType << "Custom Defined" << std::endl;
-    std::vector<double> omega;
+    std::vector<double> freq;
     std::vector<double> S;
 
     for (int i = 0;; i++) {
-      std::string w_tag = "w" + std::to_string(i);
+      std::string f_tag = "f" + std::to_string(i);
       std::string Szz_tag = "Szz" + std::to_string(i);
-      if (_sdf->HasElement(w_tag) && _sdf->HasElement(Szz_tag)) {
-        omega.push_back(_sdf->Get<double>(w_tag));
+      if (_sdf->HasElement(f_tag) && _sdf->HasElement(Szz_tag)) {
+        freq.push_back(_sdf->Get<double>(f_tag));
         S.push_back(_sdf->Get<double>(Szz_tag));
       } else {
         break;
       }
     }
 
-    if (omega.size() > 2) {  // \TODO(anyone):  Add more checks on validity of spectrum
-      this->dataPtr->Inc->SetToCustomSpectrum(omega, S, beta);
+    if (freq.size() > 2) {  // \TODO(anyone):  Add more checks on validity of spectrum
+      this->dataPtr->Inc->SetToCustomSpectrum(freq, S, beta);
     } else {
       gzwarn << "Ill-formed custom wave-spectrum specification, no waves added" << std::endl;
     }

--- a/buoy_gazebo/worlds/mbari_wec.sdf.em
+++ b/buoy_gazebo/worlds/mbari_wec.sdf.em
@@ -19,6 +19,12 @@ try:
 except NameError:
     lat_lon = [36.743850, -121.876233]  # not defined so default
 
+# Check if initial_buoy_height was passed in via empy
+try:
+    initial_buoy_height
+except NameError:
+    initial_buoy_height = 2.8  # not defined so default
+
 }@
 <sdf version="1.8">
   <world name="mbari_wec_world">
@@ -73,7 +79,7 @@ except NameError:
     </model>
 
     <model name="MBARI_WEC_ROS">
-      <pose relative_to="world">0 0 -2 0 0 0</pose>
+      <pose relative_to="world">0 0 -@(initial_buoy_height) 0 0 0</pose>
 
       <include merge="true">
         <uri>package://buoy_description/models/mbari_wec_ros</uri>

--- a/buoy_gazebo/worlds/mbari_wec_sinusoidal_piston.sdf
+++ b/buoy_gazebo/worlds/mbari_wec_sinusoidal_piston.sdf
@@ -10,8 +10,8 @@
       <elevation>0.0</elevation>
     </spherical_coordinates>
 
-    <physics name="1ms" type="ignored">
-      <max_step_size>.001</max_step_size>
+    <physics name="step" type="ignored">
+      <max_step_size>0.01</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>
 

--- a/buoy_tests/CMakeLists.txt
+++ b/buoy_tests/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_TESTING)
 
     if(buoy_add_gtest_LAUNCH_TEST)
       add_launch_test(launch/${TEST_NAME}.launch.py
-        TIMEOUT 6000
+        TIMEOUT 1000
       )
     else()
       ament_add_gtest_test(${TEST_NAME})
@@ -141,7 +141,7 @@ if(BUILD_TESTING)
     endif()
 
     add_launch_test(launch/${PYTEST_NAME}_py.launch.py
-      TIMEOUT 6000
+      TIMEOUT 1000
     )
   endfunction()
 

--- a/buoy_tests/CMakeLists.txt
+++ b/buoy_tests/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_TESTING)
 
     if(buoy_add_gtest_LAUNCH_TEST)
       add_launch_test(launch/${TEST_NAME}.launch.py
-        TIMEOUT 1000
+        TIMEOUT 2000
       )
     else()
       ament_add_gtest_test(${TEST_NAME})
@@ -141,7 +141,7 @@ if(BUILD_TESTING)
     endif()
 
     add_launch_test(launch/${PYTEST_NAME}_py.launch.py
-      TIMEOUT 1000
+      TIMEOUT 2000
     )
   endfunction()
 

--- a/buoy_tests/CMakeLists.txt
+++ b/buoy_tests/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_TESTING)
 
     if(buoy_add_gtest_LAUNCH_TEST)
       add_launch_test(launch/${TEST_NAME}.launch.py
-        TIMEOUT 2000
+        TIMEOUT 6000
       )
     else()
       ament_add_gtest_test(${TEST_NAME})
@@ -141,7 +141,7 @@ if(BUILD_TESTING)
     endif()
 
     add_launch_test(launch/${PYTEST_NAME}_py.launch.py
-      TIMEOUT 2000
+      TIMEOUT 6000
     )
   endfunction()
 

--- a/buoy_tests/launch/eh_solver_select.launch.py
+++ b/buoy_tests/launch/eh_solver_select.launch.py
@@ -59,7 +59,9 @@ def generate_launch_description():
              eh_solver_manual]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.001,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         manual_arg,

--- a/buoy_tests/launch/eh_windtarget_select.launch.py
+++ b/buoy_tests/launch/eh_windtarget_select.launch.py
@@ -59,7 +59,9 @@ def generate_launch_description():
              eh_windtarget_manual]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.001,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         manual_arg,

--- a/buoy_tests/launch/experiment_comparison_select.launch.py
+++ b/buoy_tests/launch/experiment_comparison_select.launch.py
@@ -87,7 +87,9 @@ def generate_launch_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.001,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         manual_comparison_arg,

--- a/buoy_tests/launch/incident_wave_select.launch.py
+++ b/buoy_tests/launch/incident_wave_select.launch.py
@@ -59,7 +59,9 @@ def generate_launch_description():
              incident_wave_manual]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.001,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         manual_arg,

--- a/buoy_tests/launch/no_inputs_py.launch.py
+++ b/buoy_tests/launch/no_inputs_py.launch.py
@@ -52,7 +52,9 @@ def generate_test_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.001,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,

--- a/buoy_tests/launch/no_inputs_ros_feedback.launch.py
+++ b/buoy_tests/launch/no_inputs_ros_feedback.launch.py
@@ -33,6 +33,7 @@ def generate_test_description():
         package='buoy_tests',
         executable='no_inputs_ros_feedback',
         output='screen',
+        parameters=[dict(physics_step=0.01)],
         on_exit=launch.actions.Shutdown()
     )
 
@@ -45,7 +46,9 @@ def generate_test_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.01,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,

--- a/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
@@ -66,6 +66,7 @@ class BuoyPCBiasDampingPyTest(BuoyPyTests):
         # set PC feedback rate and let server process
         # and let bias damping node load up
         self.node.set_pc_pack_rate_param(50.0)
+        self.node.get_logger().info(f'running fixture server for {preCmdIterations} iterations')
         self.test_helper.run(preCmdIterations)
         self.assertTrue(self.test_helper.run_status)
         self.assertEqual(preCmdIterations,
@@ -93,6 +94,8 @@ deadzone: {bias_policy_.deadzone}"""
         # sinusoidal force plugin is running in fixture
         prev_is_None = False
         for idx, _ in enumerate(range(0, testIterations, feedbackCheckIterations)):
+            self.node.get_logger().info('running fixture server for'
+                                        + f' {feedbackCheckIterations} iterations')
             self.test_helper.run(feedbackCheckIterations)
             self.assertTrue(self.test_helper.run_status)
             self.assertEqual(preCmdIterations + (idx + 1) * feedbackCheckIterations,

--- a/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
@@ -65,7 +65,7 @@ class BuoyPCBiasDampingPyTest(BuoyPyTests):
 
         # set PC feedback rate and let server process
         # and let bias damping node load up
-        self.node.set_pc_pack_rate_param(50.0)
+        self.node.set_pc_pack_rate(50.0)
         self.node.get_logger().info(f'running fixture server for {preCmdIterations} iterations')
         self.test_helper.run(preCmdIterations)
         self.assertTrue(self.test_helper.run_status)

--- a/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
@@ -66,7 +66,6 @@ class BuoyPCBiasDampingPyTest(BuoyPyTests):
         # set PC feedback rate and let server process
         # and let bias damping node load up
         self.node.set_pc_pack_rate(50.0)
-        self.node.get_logger().info(f'running fixture server for {preCmdIterations} iterations')
         self.test_helper.run(preCmdIterations)
         self.assertTrue(self.test_helper.run_status)
         self.assertEqual(preCmdIterations,
@@ -94,8 +93,6 @@ deadzone: {bias_policy_.deadzone}"""
         # sinusoidal force plugin is running in fixture
         prev_is_None = False
         for idx, _ in enumerate(range(0, testIterations, feedbackCheckIterations)):
-            self.node.get_logger().info('running fixture server for'
-                                        + f' {feedbackCheckIterations} iterations')
             self.test_helper.run(feedbackCheckIterations)
             self.assertTrue(self.test_helper.run_status)
             self.assertEqual(preCmdIterations + (idx + 1) * feedbackCheckIterations,

--- a/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/pc_bias_damping_ros_feedback_py.launch.py
@@ -41,7 +41,9 @@ def generate_test_description():
 
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=PHYSICS_STEP)
+                      physics_step=PHYSICS_STEP,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
     ld, locals_ = default_generate_test_description(server='fixture_server_sinusoidal_piston',
                                                     regen_models=True,
                                                     regen_kwargs=sim_params)

--- a/buoy_tests/launch/pc_commands_ros_feedback.launch.py
+++ b/buoy_tests/launch/pc_commands_ros_feedback.launch.py
@@ -75,7 +75,7 @@ def generate_test_description():
 class PCCommandsROSTest(unittest.TestCase):
 
     def test_termination(self, gazebo_test_fixture, proc_info):
-        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=2000)
+        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=600)
 
 
 @launch_testing.post_shutdown_test()

--- a/buoy_tests/launch/pc_commands_ros_feedback.launch.py
+++ b/buoy_tests/launch/pc_commands_ros_feedback.launch.py
@@ -59,7 +59,9 @@ def generate_test_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=PHYSICS_STEP)
+                      physics_step=PHYSICS_STEP,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,

--- a/buoy_tests/launch/pc_commands_ros_feedback.launch.py
+++ b/buoy_tests/launch/pc_commands_ros_feedback.launch.py
@@ -29,6 +29,9 @@ import launch_testing.actions
 from testing_utils import regenerate_models
 
 
+PHYSICS_STEP = 0.01
+
+
 def generate_test_description():
 
     config = os.path.join(
@@ -42,7 +45,8 @@ def generate_test_description():
         package='buoy_tests',
         executable='pc_commands_ros_feedback',
         output='screen',
-        parameters=[config],
+        parameters=[dict(physics_step=PHYSICS_STEP),
+                    config],
         on_exit=launch.actions.Shutdown()
     )
 
@@ -55,7 +59,7 @@ def generate_test_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=PHYSICS_STEP)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,
@@ -69,7 +73,7 @@ def generate_test_description():
 class PCCommandsROSTest(unittest.TestCase):
 
     def test_termination(self, gazebo_test_fixture, proc_info):
-        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=600)
+        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=2000)
 
 
 @launch_testing.post_shutdown_test()

--- a/buoy_tests/launch/pc_commands_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/pc_commands_ros_feedback_py.launch.py
@@ -292,4 +292,4 @@ class BuoyPCPyTest(BuoyPyTests):
         # TODO(anyone) remove once TestFixture is fixed upstream
         self.test_helper.stop()
 
-        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=2000)
+        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=600)

--- a/buoy_tests/launch/pc_commands_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/pc_commands_ros_feedback_py.launch.py
@@ -26,10 +26,13 @@ from testing_utils import BuoyPyTests
 from testing_utils import default_generate_test_description
 
 
+PHYSICS_STEP = 0.01
+
+
 def generate_test_description():
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=PHYSICS_STEP)
     return default_generate_test_description(enable_rosbag=True,
                                              rosbag_name='rosbag2_pc_cmds_py',
                                              regen_models=True,
@@ -118,8 +121,8 @@ class BuoyPCPyTest(BuoyPyTests):
         self.assertEqual(self.test_helper.iterations, 0)
         self.assertEqual(t, 0)
 
-        preCmdIterations = 15000
-        feedbackCheckIterations = 100
+        preCmdIterations = int(15 / PHYSICS_STEP)
+        feedbackCheckIterations = int(0.1 / PHYSICS_STEP)
 
         #######################################
         # Check Default Winding Current Damping
@@ -129,7 +132,7 @@ class BuoyPCPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         expected_wind_curr = \
             torque_policy_.winding_current_target(self.node.rpm_,
@@ -146,7 +149,7 @@ class BuoyPCPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         ##################################################
         # Winding Current
@@ -166,7 +169,7 @@ class BuoyPCPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         expected_wind_curr = self.winding_current_limiter(wc)
         self.assertGreater(self.node.wind_curr_, expected_wind_curr - 0.1)
@@ -190,7 +193,7 @@ class BuoyPCPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         self.assertGreater(self.node.scale_, scale - 0.01)
         self.assertLess(self.node.scale_, scale + 0.01)
@@ -213,14 +216,14 @@ class BuoyPCPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         self.assertGreater(self.node.retract_, retract - 0.01)
         self.assertLess(self.node.retract_, retract + 0.01)
 
         ##################################################
         # Check return to default winding current damping
-        torque_timeout_iterations = 2500
+        torque_timeout_iterations = int(2.5 / PHYSICS_STEP)
 
         # Run to let winding current finish
         self.test_helper.run(torque_timeout_iterations - 2 * feedbackCheckIterations)
@@ -232,7 +235,7 @@ class BuoyPCPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         expected_wind_curr = \
             torque_policy_.winding_current_target(self.node.rpm_,
@@ -253,8 +256,8 @@ class BuoyPCPyTest(BuoyPyTests):
                          self.node.pc_retract_future_.result().result.OK)
 
         # Run to let bias curr process
-        bias_curr_iterations = 9000
-        bias_curr_timeout_iterations = 10000
+        bias_curr_iterations = int(9 / PHYSICS_STEP)
+        bias_curr_timeout_iterations = int(10 / PHYSICS_STEP)
         self.test_helper.run(bias_curr_iterations)
         self.assertTrue(self.test_helper.run_status)
         self.assertEqual(preCmdIterations + 2 * feedbackCheckIterations +
@@ -263,7 +266,7 @@ class BuoyPCPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         self.assertGreater(self.node.bias_curr_, bc - 0.1)
         self.assertLess(self.node.bias_curr_, bc + 0.1)
@@ -279,7 +282,7 @@ class BuoyPCPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         self.assertGreater(self.node.bias_curr_, -0.1)
         self.assertLess(self.node.bias_curr_, 0.1)
@@ -287,4 +290,4 @@ class BuoyPCPyTest(BuoyPyTests):
         # TODO(anyone) remove once TestFixture is fixed upstream
         self.test_helper.stop()
 
-        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=30)
+        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=2000)

--- a/buoy_tests/launch/pc_commands_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/pc_commands_ros_feedback_py.launch.py
@@ -32,7 +32,9 @@ PHYSICS_STEP = 0.01
 def generate_test_description():
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=PHYSICS_STEP)
+                      physics_step=PHYSICS_STEP,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
     return default_generate_test_description(enable_rosbag=True,
                                              rosbag_name='rosbag2_pc_cmds_py',
                                              regen_models=True,

--- a/buoy_tests/launch/run_server.launch.py
+++ b/buoy_tests/launch/run_server.launch.py
@@ -39,7 +39,9 @@ def generate_launch_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.01)
+                      physics_step=0.01,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,

--- a/buoy_tests/launch/run_server.launch.py
+++ b/buoy_tests/launch/run_server.launch.py
@@ -39,7 +39,7 @@ def generate_launch_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.01)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,

--- a/buoy_tests/launch/sc_commands_ros_feedback.launch.py
+++ b/buoy_tests/launch/sc_commands_ros_feedback.launch.py
@@ -65,7 +65,7 @@ def generate_test_description():
 class SCCommandsROSTest(unittest.TestCase):
 
     def test_termination(self, gazebo_test_fixture, proc_info):
-        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=2000)
+        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=600)
 
 
 @launch_testing.post_shutdown_test()

--- a/buoy_tests/launch/sc_commands_ros_feedback.launch.py
+++ b/buoy_tests/launch/sc_commands_ros_feedback.launch.py
@@ -26,6 +26,9 @@ import launch_testing.actions
 from testing_utils import regenerate_models
 
 
+PHYSICS_STEP = 0.01
+
+
 def generate_test_description():
 
     # Test fixture
@@ -33,6 +36,7 @@ def generate_test_description():
         package='buoy_tests',
         executable='sc_commands_ros_feedback',
         output='screen',
+        parameters=[dict(physics_step=PHYSICS_STEP)],
         on_exit=launch.actions.Shutdown()
     )
 
@@ -45,7 +49,7 @@ def generate_test_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=PHYSICS_STEP)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,
@@ -59,7 +63,7 @@ def generate_test_description():
 class SCCommandsROSTest(unittest.TestCase):
 
     def test_termination(self, gazebo_test_fixture, proc_info):
-        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=1000)
+        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=2000)
 
 
 @launch_testing.post_shutdown_test()

--- a/buoy_tests/launch/sc_commands_ros_feedback.launch.py
+++ b/buoy_tests/launch/sc_commands_ros_feedback.launch.py
@@ -49,7 +49,9 @@ def generate_test_description():
              bridge]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=PHYSICS_STEP)
+                      physics_step=PHYSICS_STEP,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,

--- a/buoy_tests/launch/sc_pump_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/sc_pump_ros_feedback_py.launch.py
@@ -21,10 +21,13 @@ from testing_utils import BuoyPyTests
 from testing_utils import default_generate_test_description
 
 
+PHYSICS_STEP = 0.01
+
+
 def generate_test_description():
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=PHYSICS_STEP)
     return default_generate_test_description(enable_rosbag=True,
                                              rosbag_name='rosbag2_sc_pump_py',
                                              regen_models=True,
@@ -39,9 +42,9 @@ class BuoySCPumpPyTest(BuoyPyTests):
         self.assertEqual(t, 0)
         self.assertEqual(self.test_helper.iterations, 0)
 
-        preCmdIterations = 45000
-        statusCheckIterations = 1000
-        postCmdIterations = 60000
+        preCmdIterations = int(45 / PHYSICS_STEP)
+        statusCheckIterations = int(1 / PHYSICS_STEP)
+        postCmdIterations = int(60 / PHYSICS_STEP)
 
         # Run simulation server and allow piston to settle
         self.test_helper.run(preCmdIterations)
@@ -50,7 +53,7 @@ class BuoySCPumpPyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         # Before Pump command
         pre_pump_range_finder = self.node.range_finder_
@@ -84,7 +87,7 @@ class BuoySCPumpPyTest(BuoyPyTests):
         self.assertEqual(preCmdIterations + 500, self.test_helper.iterations)
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         # Check status field
         self.assertFalse(self.node.sc_status_ & SCRecord.RELIEF_VALVE_REQUEST,
@@ -112,7 +115,7 @@ class BuoySCPumpPyTest(BuoyPyTests):
                              self.test_helper.iterations)
             time.sleep(0.5)
             t, _ = clock.now().seconds_nanoseconds()
-            self.assertEqual(t, self.test_helper.iterations // 1000)
+            self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
             if n % 2 == 1:
                 self.assertFalse(self.node.sc_status_ & SCRecord.PUMP_TOGGLE,
@@ -133,7 +136,7 @@ class BuoySCPumpPyTest(BuoyPyTests):
                          self.test_helper.iterations)
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         # Check piston motion
         post_pump_range_finder = self.node.range_finder_

--- a/buoy_tests/launch/sc_pump_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/sc_pump_ros_feedback_py.launch.py
@@ -27,7 +27,9 @@ PHYSICS_STEP = 0.01
 def generate_test_description():
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=PHYSICS_STEP)
+                      physics_step=PHYSICS_STEP,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
     return default_generate_test_description(enable_rosbag=True,
                                              rosbag_name='rosbag2_sc_pump_py',
                                              regen_models=True,

--- a/buoy_tests/launch/sc_valve_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/sc_valve_ros_feedback_py.launch.py
@@ -153,4 +153,4 @@ class BuoySCValvePyTest(BuoyPyTests):
         # TODO(anyone) remove once TestFixture is fixed upstream
         self.test_helper.stop()
 
-        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=30)
+        proc_info.assertWaitForShutdown(process=gazebo_test_fixture, timeout=600)

--- a/buoy_tests/launch/sc_valve_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/sc_valve_ros_feedback_py.launch.py
@@ -27,7 +27,9 @@ PHYSICS_STEP = 0.01
 def generate_test_description():
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=PHYSICS_STEP)
+                      physics_step=PHYSICS_STEP,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
     return default_generate_test_description(regen_models=True,
                                              regen_kwargs=sim_params)
 

--- a/buoy_tests/launch/sc_valve_ros_feedback_py.launch.py
+++ b/buoy_tests/launch/sc_valve_ros_feedback_py.launch.py
@@ -21,10 +21,13 @@ from testing_utils import BuoyPyTests
 from testing_utils import default_generate_test_description
 
 
+PHYSICS_STEP = 0.01
+
+
 def generate_test_description():
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=PHYSICS_STEP)
     return default_generate_test_description(regen_models=True,
                                              regen_kwargs=sim_params)
 
@@ -37,9 +40,9 @@ class BuoySCValvePyTest(BuoyPyTests):
         self.assertEqual(t, 0)
         self.assertEqual(self.test_helper.iterations, 0)
 
-        preCmdIterations = 45000
-        statusCheckIterations = 1000
-        postCmdIterations = 5000
+        preCmdIterations = int(45 / PHYSICS_STEP)
+        statusCheckIterations = int(1 / PHYSICS_STEP)
+        postCmdIterations = int(5 / PHYSICS_STEP)
 
         # Run simulation server and wait for piston to settle
         self.test_helper.run(preCmdIterations)
@@ -48,7 +51,7 @@ class BuoySCValvePyTest(BuoyPyTests):
 
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         # Before Valve command
         pre_valve_range_finder = self.node.range_finder_
@@ -82,7 +85,7 @@ class BuoySCValvePyTest(BuoyPyTests):
         self.assertEqual(preCmdIterations + statusCheckIterations, self.test_helper.iterations)
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         # Check status field
         self.assertTrue(self.node.sc_status_ & SCRecord.RELIEF_VALVE_REQUEST,
@@ -114,7 +117,7 @@ class BuoySCValvePyTest(BuoyPyTests):
                          self.test_helper.iterations)
         time.sleep(0.5)
         t, _ = clock.now().seconds_nanoseconds()
-        self.assertEqual(t, self.test_helper.iterations // 1000)
+        self.assertEqual(t, int(self.test_helper.iterations * PHYSICS_STEP))
 
         # Check Status goes back to normal
         self.assertFalse(self.node.sc_status_ & SCRecord.RELIEF_VALVE_REQUEST,

--- a/buoy_tests/launch/wave_body_interactions_heaveonly.launch.py
+++ b/buoy_tests/launch/wave_body_interactions_heaveonly.launch.py
@@ -39,7 +39,9 @@ def generate_test_description():
     nodes = [gazebo_test_fixture]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.001,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,

--- a/buoy_tests/launch/wave_body_interactions_pitchonly.launch.py
+++ b/buoy_tests/launch/wave_body_interactions_pitchonly.launch.py
@@ -39,7 +39,9 @@ def generate_test_description():
     nodes = [gazebo_test_fixture]
     sim_params = dict(inc_wave_spectrum='inc_wave_spectrum_type:None',
                       physics_rtf=11.0,
-                      physics_step=0.001)
+                      physics_step=0.01,
+                      initial_piston_position=2.03,
+                      initial_buoy_height=2.0)
 
     return launch.LaunchDescription([
         OpaqueFunction(function=regenerate_models,

--- a/buoy_tests/testing_utils/utils.py
+++ b/buoy_tests/testing_utils/utils.py
@@ -15,6 +15,7 @@
 import asyncio
 import os
 from threading import Thread
+import time
 import unittest
 
 from ament_index_python.packages import get_package_share_directory
@@ -369,6 +370,12 @@ class BuoyPyTests(unittest.TestCase):
     NODE_NAME = 'test_interface_py'
     CLI_ARGS = None
 
+    def executor_spin(self):
+        # rate = self.node.create_rate(50)
+        while rclpy.ok():
+            self.executor.spin_once()
+            time.sleep(1./50.)
+
     def setUp(self):
         rclpy.init()
         self.test_helper = TestHelper()
@@ -378,7 +385,7 @@ class BuoyPyTests(unittest.TestCase):
         self.executor = MultiThreadedExecutor()
         self.executor.add_node(self.node)
         self.executor.add_node(self.test_helper)
-        self.executor_thread = Thread(target=self.executor.spin)
+        self.executor_thread = Thread(target=self.executor_spin)
         self.executor_thread.daemon = True
         self.executor_thread.start()
         # TODO(anyone) put back when TestFixture fixed upstream

--- a/buoy_tests/testing_utils/utils.py
+++ b/buoy_tests/testing_utils/utils.py
@@ -15,7 +15,6 @@
 import asyncio
 import os
 from threading import Thread
-import time
 import unittest
 
 from ament_index_python.packages import get_package_share_directory
@@ -329,7 +328,6 @@ class TestHelper(rclpyNode):
         req = RunServer.Request()
         req.iterations = _iterations
         future = self.fixture_client.call_async(req)
-        self.get_logger().info('waiting for fixture server run future response...')
         await future
         self.run_status = future.result().success
         self.iterations += future.result().iterations
@@ -370,12 +368,6 @@ class BuoyPyTests(unittest.TestCase):
     NODE_NAME = 'test_interface_py'
     CLI_ARGS = None
 
-    def executor_spin(self):
-        # rate = self.node.create_rate(50)
-        while rclpy.ok():
-            self.executor.spin_once()
-            time.sleep(1./50.)
-
     def setUp(self):
         rclpy.init()
         self.test_helper = TestHelper()
@@ -385,7 +377,7 @@ class BuoyPyTests(unittest.TestCase):
         self.executor = MultiThreadedExecutor()
         self.executor.add_node(self.node)
         self.executor.add_node(self.test_helper)
-        self.executor_thread = Thread(target=self.executor_spin)
+        self.executor_thread = Thread(target=self.executor.spin)
         self.executor_thread.daemon = True
         self.executor_thread.start()
         # TODO(anyone) put back when TestFixture fixed upstream

--- a/buoy_tests/testing_utils/utils.py
+++ b/buoy_tests/testing_utils/utils.py
@@ -328,6 +328,7 @@ class TestHelper(rclpyNode):
         req = RunServer.Request()
         req.iterations = _iterations
         future = self.fixture_client.call_async(req)
+        self.get_logger().info('waiting for fixture server run future response...')
         await future
         self.run_status = future.result().success
         self.iterations += future.result().iterations

--- a/buoy_tests/testing_utils/utils.py
+++ b/buoy_tests/testing_utils/utils.py
@@ -97,7 +97,8 @@ def regenerate_models(context, *args, **kwargs):
 
     # fill mbari_wec world template with params
     supported_mbari_wec_world_params = ['physics_step',
-                                        'physics_rtf']
+                                        'physics_rtf',
+                                        'initial_buoy_height']
     mbari_wec_world_params = []
     for world_param in supported_mbari_wec_world_params:
         if world_param in kwargs:
@@ -112,12 +113,13 @@ def regenerate_models(context, *args, **kwargs):
                                         'inc_wave_seed',
                                         'battery_soc',
                                         'battery_emf',
+                                        'initial_piston_position',
                                         'x_mean_pos',
                                         'inc_wave_spectrum']
     mbari_wec_model_params = []
     for world_param in supported_mbari_wec_model_params:
         if world_param in kwargs:
-            if 'inc_wave_spectrum_type' in kwargs[world_param]:
+            if 'inc_wave_spectrum_type' in str(kwargs[world_param]):
                 inc_wave_spectrum = kwargs[world_param].split(';')
                 no_params = len(inc_wave_spectrum) > 1
                 inc_wave_spectrum_type = inc_wave_spectrum[0].split(':')

--- a/buoy_tests/tests/experiment_comparison.cpp
+++ b/buoy_tests/tests/experiment_comparison.cpp
@@ -233,7 +233,7 @@ protected:
     return true;
   }
 
-// runs once and is preserved for all `TEST_F`
+  // runs once and is preserved for all `TEST_F`
   static void SetUpTestCase()
   {
     rclcpp::init(argc_, argv_);

--- a/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
+++ b/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
@@ -122,7 +122,7 @@ TEST(BuoyTests, RunServer)
 
       EXPECT_EQ(iterations - initial_iterations, request->iterations);
 
-      RCLCPP_DEBUG_STREAM(
+      RCLCPP_INFO_STREAM(
         rclcpp::get_logger("run_server"),
         "Response: " << std::boolalpha << response->success << std::noboolalpha);
     }

--- a/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
+++ b/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
@@ -36,7 +36,7 @@ using namespace std::chrono;
 TEST(BuoyTests, RunServer)
 {
   // Skip debug messages to run faster
-  gz::common::Console::SetVerbosity(4);
+  gz::common::Console::SetVerbosity(3);
 
   // Setup fixture
   gz::sim::ServerConfig config;

--- a/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
+++ b/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
@@ -24,7 +24,6 @@
 #include <gz/sim/Server.hh>
 #include <gz/sim/Util.hh>
 #include <gz/sim/TestFixture.hh>
-#include <gz/transport/Node.hh>
 
 #include <buoy_tests/srv/run_server.hpp>
 
@@ -104,6 +103,7 @@ TEST(BuoyTests, RunServer)
         RCLCPP_INFO(
           rclcpp::get_logger("run_server"),
           "Incoming request to shutdown");
+        stop = true;
         rclcpp::shutdown();
         response->success = true;
         return;
@@ -118,10 +118,9 @@ TEST(BuoyTests, RunServer)
       static const bool blocking = true;
       static const bool paused = false;
       response->success = fixture->Server()->Run(blocking, request->iterations, paused);
-      response->success = fixture->Server()->RunOnce(true);
-      response->iterations = iterations - initial_iterations - 1U;
+      response->iterations = iterations - initial_iterations;
 
-      EXPECT_EQ(response->iterations, request->iterations);
+      EXPECT_EQ(iterations - initial_iterations, request->iterations);
 
       RCLCPP_DEBUG_STREAM(
         rclcpp::get_logger("run_server"),
@@ -147,5 +146,6 @@ TEST(BuoyTests, RunServer)
   }
 
   std::this_thread::sleep_for(1s);  // needed for launch_test to know we shut down
+
   RCLCPP_INFO(rclcpp::get_logger("run_server"), "Shutting down test server.");
 }

--- a/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
+++ b/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
@@ -36,7 +36,7 @@ using namespace std::chrono;
 TEST(BuoyTests, RunServer)
 {
   // Skip debug messages to run faster
-  gz::common::Console::SetVerbosity(3);
+  gz::common::Console::SetVerbosity(4);
 
   // Setup fixture
   gz::sim::ServerConfig config;

--- a/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
+++ b/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
@@ -131,8 +131,8 @@ TEST(BuoyTests, RunServer)
   RCLCPP_INFO(rclcpp::get_logger("run_server"), "Ready to run test server.");
 
   // rclcpp::spin(node);
-  rclcpp::executors::MultiThreadedExecutor::SharedPtr executor =
-    std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr executor =
+    std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
   executor->add_node(node);
 
   rclcpp::Rate rate(50.0);

--- a/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
+++ b/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
@@ -31,6 +31,9 @@
 #include <rclcpp/rclcpp.hpp>
 
 
+// NOLINTNEXTLINE
+using namespace std::chrono;
+
 TEST(BuoyTests, RunServer)
 {
   // Skip debug messages to run faster
@@ -89,6 +92,7 @@ TEST(BuoyTests, RunServer)
   }
 
   std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("gz_fixture_server");
+  std::atomic<bool> stop = false;
 
   rclcpp::Service<buoy_tests::srv::RunServer>::SharedPtr service =
     node->create_service<buoy_tests::srv::RunServer>(
@@ -127,6 +131,21 @@ TEST(BuoyTests, RunServer)
 
   RCLCPP_INFO(rclcpp::get_logger("run_server"), "Ready to run test server.");
 
-  rclcpp::spin(node);
+  // rclcpp::spin(node);
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr executor =
+    std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  executor->add_node(node);
+
+  rclcpp::Rate rate(50.0);
+  while (rclcpp::ok() && !stop) {
+    executor->spin_once();
+    rate.sleep();
+  }
+
+  if (executor) {
+    executor->cancel();
+  }
+
+  std::this_thread::sleep_for(1s);  // needed for launch_test to know we shut down
   RCLCPP_INFO(rclcpp::get_logger("run_server"), "Shutting down test server.");
 }

--- a/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
+++ b/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
@@ -108,7 +108,7 @@ TEST(BuoyTests, RunServer)
         response->success = true;
         return;
       } else {
-        RCLCPP_DEBUG_STREAM(
+        RCLCPP_INFO_STREAM(
           rclcpp::get_logger("run_server"),
           "Incoming request\niterations: " << request->iterations);
       }

--- a/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
+++ b/buoy_tests/tests/fixture_server_sinusoidal_piston.cpp
@@ -108,7 +108,7 @@ TEST(BuoyTests, RunServer)
         response->success = true;
         return;
       } else {
-        RCLCPP_INFO_STREAM(
+        RCLCPP_DEBUG_STREAM(
           rclcpp::get_logger("run_server"),
           "Incoming request\niterations: " << request->iterations);
       }
@@ -122,7 +122,7 @@ TEST(BuoyTests, RunServer)
 
       EXPECT_EQ(iterations - initial_iterations, request->iterations);
 
-      RCLCPP_INFO_STREAM(
+      RCLCPP_DEBUG_STREAM(
         rclcpp::get_logger("run_server"),
         "Response: " << std::boolalpha << response->success << std::noboolalpha);
     }

--- a/buoy_tests/tests/sc_commands_ros_feedback.cpp
+++ b/buoy_tests/tests/sc_commands_ros_feedback.cpp
@@ -34,12 +34,14 @@
 // NOLINTNEXTLINE
 using namespace std::chrono;
 
+constexpr double PHYSICS_STEP{0.001};
 constexpr double INCHES_TO_METERS{0.0254};
 
 class SCROSNode final : public buoy_api::Interface<SCROSNode>
 {
 public:
   rclcpp::Clock::SharedPtr clock_{nullptr};
+  double physics_step{PHYSICS_STEP};
   float range_finder_{0.0F};
   std::atomic<uint16_t> status_{0U};
 
@@ -54,6 +56,7 @@ public:
         "use_sim_time",
         true));
 
+    this->set_params();
     node_ = std::shared_ptr<SCROSNode>(this, [](SCROSNode *) {});  // null deleter
     clock_ = this->get_clock();
 
@@ -95,6 +98,12 @@ private:
     status_ = data.status;
   }
 
+  void set_params()
+  {
+    this->declare_parameter("physics_step", this->physics_step);
+    this->physics_step = this->get_parameter("physics_step").as_double();
+  }
+
   std::thread thread_executor_spin_;
   std::atomic<bool> stop_{false};
   rclcpp::Node::SharedPtr node_{nullptr};
@@ -109,6 +118,28 @@ protected:
   std::unique_ptr<gz::sim::TestFixture> fixture{nullptr};
   std::unique_ptr<SCROSNode> node{nullptr};
   gz::sim::Entity buoyEntity{gz::sim::kNullEntity};
+  static int argc_;
+  static char ** argv_;
+
+public:
+  static void init(int argc, char * argv[])
+  {
+    argc_ = argc;
+    argv_ = argv;
+  }
+
+protected:
+  // runs once and is preserved for all `TEST_F`
+  static void SetUpTestCase()
+  {
+    rclcpp::init(argc_, argv_);
+  }
+
+  // runs once after all `TEST_F` have completed
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
 
   virtual void SetUp()
   {
@@ -163,10 +194,16 @@ protected:
   }
 };
 
+int BuoySCTests::argc_;
+char ** BuoySCTests::argv_;
+
+
 //////////////////////////////////////////////////
 TEST_F(BuoySCTests, SCValveROS)
 {
-  int preCmdIterations{45000}, statusCheckIterations{1000}, postCmdIterations{5000};
+  int preCmdIterations{static_cast<int>(45 / node->physics_step)};
+  int statusCheckIterations{static_cast<int>(1 / node->physics_step)};
+  int postCmdIterations{static_cast<int>(5 / node->physics_step)};
 
   // Run simulation server and wait for piston to settle
   fixture->Server()->Run(true /*blocking*/, preCmdIterations, false /*paused*/);
@@ -175,7 +212,7 @@ TEST_F(BuoySCTests, SCValveROS)
   std::this_thread::sleep_for(500ms);
   EXPECT_EQ(
     static_cast<int>(node->clock_->now().seconds()),
-    static_cast<int>(iterations / 1000.0F));
+    static_cast<int>(iterations * node->physics_step));
 
   // Before Valve command
   float pre_valve_range_finder = node->range_finder_;
@@ -221,7 +258,7 @@ TEST_F(BuoySCTests, SCValveROS)
   std::this_thread::sleep_for(500ms);
   EXPECT_EQ(
     static_cast<int>(node->clock_->now().seconds()),
-    static_cast<int>(iterations / 1000.0F));
+    static_cast<int>(iterations * node->physics_step));
 
   // Check status field
   EXPECT_TRUE(
@@ -264,7 +301,7 @@ TEST_F(BuoySCTests, SCValveROS)
   std::this_thread::sleep_for(500ms);
   EXPECT_EQ(
     static_cast<int>(node->clock_->now().seconds()),
-    static_cast<int>(iterations / 1000.0F));
+    static_cast<int>(iterations * node->physics_step));
 
   // Check Status goes back to normal
   EXPECT_FALSE(
@@ -315,7 +352,9 @@ TEST_F(BuoySCTests, SCValveROS)
 //////////////////////////////////////////////////
 TEST_F(BuoySCTests, SCPumpROS)
 {
-  int preCmdIterations{45000}, statusCheckIterations{1000}, postCmdIterations{60000};
+  int preCmdIterations{static_cast<int>(45 / node->physics_step)};
+  int statusCheckIterations{static_cast<int>(1 / node->physics_step)};
+  int postCmdIterations{static_cast<int>(60 / node->physics_step)};
 
   // Run simulation server and allow piston to settle
   fixture->Server()->Run(true /*blocking*/, preCmdIterations, false /*paused*/);
@@ -324,7 +363,7 @@ TEST_F(BuoySCTests, SCPumpROS)
   std::this_thread::sleep_for(500ms);
   EXPECT_EQ(
     static_cast<int>(node->clock_->now().seconds()),
-    static_cast<int>(iterations / 1000.0F));
+    static_cast<int>(iterations * node->physics_step));
 
   // Before Pump command
   float pre_pump_range_finder = node->range_finder_;
@@ -371,7 +410,7 @@ TEST_F(BuoySCTests, SCPumpROS)
   std::this_thread::sleep_for(500ms);
   EXPECT_EQ(
     static_cast<int>(node->clock_->now().seconds()),
-    static_cast<int>(iterations / 1000.0F));
+    static_cast<int>(iterations * node->physics_step));
 
   // Check status field
   EXPECT_FALSE(
@@ -407,7 +446,7 @@ TEST_F(BuoySCTests, SCPumpROS)
     std::this_thread::sleep_for(500ms);
     EXPECT_EQ(
       static_cast<int>(node->clock_->now().seconds()),
-      static_cast<int>(iterations / 1000.0F));
+      static_cast<int>(iterations * node->physics_step));
 
     if (n % 2U == 1) {
       EXPECT_FALSE(
@@ -435,7 +474,7 @@ TEST_F(BuoySCTests, SCPumpROS)
   std::this_thread::sleep_for(500ms);
   EXPECT_EQ(
     static_cast<int>(node->clock_->now().seconds()),
-    static_cast<int>(iterations / 1000.0F));
+    static_cast<int>(iterations * node->physics_step));
 
   // Check piston motion
   float post_pump_range_finder = node->range_finder_;
@@ -455,4 +494,13 @@ TEST_F(BuoySCTests, SCPumpROS)
 
   // Sanity check that the test ran
   EXPECT_NE(gz::sim::kNullEntity, buoyEntity);
+  std::this_thread::sleep_for(1s);  // needed for launch_test to know we shut down
+}
+
+
+int main(int argc, char * argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  BuoySCTests::init(argc, argv);  // pass args to rclcpp init
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
It became more expedient to test certain run configurations by directly overriding sim params in `mbari_wec.launch.py`

@hamilton8415 I also added the swap for Custom spectra to use freq in Hz in this PR. Incidentally, this is the reason I wanted to be able to override params to test specific configs without batching. I found an instability in the sim for the following config:

```
ros2 launch buoy_gazebo mbari_wec.launch.py inc_wave_spectrum:='inc_wave_spectrum_type:Custom' seed:=42 physics_rtf:=10 physics_step:=0.09 door_state:=closed scale_factor:=0.5 battery_soc:=0.25 x_mean_pos:=0.5
```

It fails almost immediately. If I change to `physics_step:=0.01`, it still crashes but takes longer. And, `physics_step:=0.001` didn't crash in the few minutes I checked, but I can't guarantee it won't still run away eventually.

The buoy & heave cone fly off the screen pretty quickly. 

The crash log:
```
[ruby $(which gz) sim-1] ODE INTERNAL ERROR 1: assertion "aabbBound >= dMinIntExact && aabbBound < dMaxIntExact" failed in collide() [collision_space.cpp:460]
[ruby $(which gz) sim-1] Stack trace (most recent call last):
[ruby $(which gz) sim-1] #31   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df434c96, in
[ruby $(which gz) sim-1] #30   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df431fc5, in
[ruby $(which gz) sim-1] #29   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df42fc34, in
[ruby $(which gz) sim-1] #28   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df37ba1e, in
[ruby $(which gz) sim-1] #27   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df2a69ac, in rb_protect
[ruby $(which gz) sim-1] #26   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df43ec61, in rb_yield
[ruby $(which gz) sim-1] #25   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df43a30c, in rb_vm_exec
[ruby $(which gz) sim-1] #24   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df434c96, in
[ruby $(which gz) sim-1] #23   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df431fc5, in
[ruby $(which gz) sim-1] #22   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df42fc34, in
[ruby $(which gz) sim-1] #21   Object "/usr/lib/x86_64-linux-gnu/ruby/3.0.0/fiddle.so", at 0x7fd3df5c844b, in
[ruby $(which gz) sim-1] #20   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7fd3df3fd088, in rb_nogvl
[ruby $(which gz) sim-1] #19   Object "/usr/lib/x86_64-linux-gnu/ruby/3.0.0/fiddle.so", at 0x7fd3df5c7d6b, in
[ruby $(which gz) sim-1] #18   Object "/lib/x86_64-linux-gnu/libffi.so.8", at 0x7fd3df5b9492, in
[ruby $(which gz) sim-1] #17   Object "/lib/x86_64-linux-gnu/libffi.so.8", at 0x7fd3df5bce2d, in
[ruby $(which gz) sim-1] #16   Object "/usr/lib/x86_64-linux-gnu/libgz-sim7-gz.so.7.5.0", at 0x7fd3df09980d, in runServer
[ruby $(which gz) sim-1] #15   Object "/lib/x86_64-linux-gnu/libgz-sim7.so.7", at 0x7fd3da3397e5, in
[ruby $(which gz) sim-1] #14   Object "/lib/x86_64-linux-gnu/libgz-sim7.so.7", at 0x7fd3da34647a, in gz::sim::v7::SimulationRunner::Run(unsigned long)
[ruby $(which gz) sim-1] #13   Object "/lib/x86_64-linux-gnu/libgz-sim7.so.7", at 0x7fd3da345b40, in gz::sim::v7::SimulationRunner::Step(gz::sim::v7::UpdateInfo const&)
[ruby $(which gz) sim-1] #12   Object "/lib/x86_64-linux-gnu/libgz-sim7.so.7", at 0x7fd3da3423e2, in gz::sim::v7::SimulationRunner::UpdateSystems()
[ruby $(which gz) sim-1] #11   Object "/usr/lib/x86_64-linux-gnu/gz-sim-7/plugins/libgz-sim-physics-system.so", at 0x7fd3a0127a86, in gz::sim::v7::systems::Physics::Update(gz::sim::v7::UpdateInfo const&, gz::sim::v7::EntityComponentManager&)
[ruby $(which gz) sim-1] #10   Object "/usr/lib/x86_64-linux-gnu/gz-sim-7/plugins/libgz-sim-physics-system.so", at 0x7fd3a0128101, in gz::sim::v7::systems::PhysicsPrivate::Step(std::chrono::duration<long, std::ratio<1l, 1000000000l> > const&)
[ruby $(which gz) sim-1] #9    Object "/usr/lib/x86_64-linux-gnu/gz-physics-6/engine-plugins/libgz-physics-dartsim-plugin.so", at 0x7fd35c391a3b, in gz::physics::dartsim::SimulationFeatures::WorldForwardStep(gz::physics::Identity const&, gz::physics::SpecifyData<gz::physics::RequireData<gz::physics::WorldPoses>, gz::physics::ExpectData<gz::physics::ChangedWorldPoses, gz::physics::Contacts, gz::physics::JointPositions> >&, gz::physics::CompositeData&, gz::physics::ExpectData<gz::physics::ApplyExternalForceTorques, gz::physics::ApplyGeneralizedForces, gz::physics::VelocityControlCommands, gz::physics::ServoControlCommands, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&)
[ruby $(which gz) sim-1] #8    Object "/lib/x86_64-linux-gnu/libdart.so.6.12", at 0x7fd2d7566e73, in dart::simulation::World::step(bool)
[ruby $(which gz) sim-1] #7    Object "/lib/x86_64-linux-gnu/libdart.so.6.12", at 0x7fd2d754c705, in dart::constraint::ConstraintSolver::solve()
[ruby $(which gz) sim-1] #6    Object "/lib/x86_64-linux-gnu/libdart.so.6.12", at 0x7fd2d754afe1, in dart::constraint::ConstraintSolver::updateConstraints()
[ruby $(which gz) sim-1] #5    Object "/lib/x86_64-linux-gnu/libdart-collision-ode.so.6.12", at 0x7fd3629761cb, in dart::collision::OdeCollisionDetector::collide(dart::collision::CollisionGroup*, dart::collision::CollisionOption const&, dart::collision::CollisionResult*)
[ruby $(which gz) sim-1] #4    Object "/lib/x86_64-linux-gnu/libode.so.8", at 0x7fd35c51a266, in dxHashSpace::collide(void*, void (*)(void*, dxGeom*, dxGeom*))
[ruby $(which gz) sim-1] #3    Object "/lib/x86_64-linux-gnu/libode.so.8", at 0x7fd35c5227b7, in dDebug
[ruby $(which gz) sim-1] #2    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7fd3dee287f2, in abort
[ruby $(which gz) sim-1] #1    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7fd3dee42475, in raise
[ruby $(which gz) sim-1] #0    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7fd3dee96a7c, in pthread_kill
[ruby $(which gz) sim-1] Aborted (Signal sent by tkill() 951633 11883)
```