### PR TITLE
Modified to use fshydro v1.3.0 in CI

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -38,7 +38,7 @@ rosdep init
 rosdep update
 rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO
 
-git clone https://github.com/hamilton8415/FreeSurfaceHydrodynamics.git
+git clone -b v1.3.0 --single-branch https://github.com/hamilton8415/FreeSurfaceHydrodynamics.git
 cd FreeSurfaceHydrodynamics
 touch COLCON_IGNORE
 mkdir build


### PR DESCRIPTION
Changed build-and-test.sh to use v1.3.0 of the free-surface hydro library.  At this time CI is cloning the repo and not using the ppa/debians/apt-get.  This is fine but it was using the latest main branch, so this change makes that more specific.  There is an PR associated with this one in mbari_wec that should be merged at the same time, that PR is just documentation changes to match...  