### PR TITLE
Debug flag for WaveBodyInteractions plugin

### DIFF
--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -265,8 +265,9 @@ if not ignore_piston_mean_pos:
       <P0>@(print(f'{P0_l:.00f}', end=''))</P0>
     </plugin>
 
-    <plugin filename="WaveBodyInteractions" name="buoy_gazebo::WaveBodyInteractions">  
+    <plugin filename="WaveBodyInteractions" name="buoy_gazebo::WaveBodyInteractions">
       <LinkName>Buoy</LinkName>
+      <debug>false</debug>
       <WaterplaneOrigin_x>0</WaterplaneOrigin_x>  <!-- Waterplane origin relative to link origin -->
       <WaterplaneOrigin_y>0</WaterplaneOrigin_y>
       <WaterplaneOrigin_z>2.46</WaterplaneOrigin_z> 

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
@@ -360,7 +360,7 @@ void ElectroHydraulicPTO::PreUpdate(
   if (i_try > 0) {
     std::stringstream warning;
     warning << "Warning: Reduced piston to achieve convergence" << std::endl;
-    igndbg << warning.str();
+    gzdbg << warning.str();
   }
 
   if (solver_info != 1) {
@@ -369,7 +369,7 @@ void ElectroHydraulicPTO::PreUpdate(
     warning << "Warning: Numericals solver in ElectroHydraulicPTO did not converge" << std::endl;
     warning << "solver info: [" << solver_info << "]" << std::endl;
     warning << "=================================" << std::endl;
-    igndbg << warning.str();
+    gzdbg << warning.str();
   }
 
   // Solve Electrical

--- a/buoy_gazebo/src/WaveBodyInteractions/WaveBodyInteractions.cpp
+++ b/buoy_gazebo/src/WaveBodyInteractions/WaveBodyInteractions.cpp
@@ -113,7 +113,7 @@ void WaveBodyInteractions::Configure(
   if (!_sdf->HasElement("LinkName")) {
     gzerr << "You musk specify a <LinkName> for the wavebodyinteraction "
       "plugin to act upon"
-           << "Failed to initialize." << std::endl;
+          << "Failed to initialize." << std::endl;
     return;
   }
   auto linkName = _sdf->Get<std::string>("LinkName");
@@ -271,7 +271,7 @@ void WaveBodyInteractions::PreUpdate(
   Eigen::VectorXd BuoyancyForce(6);
   BuoyancyForce = this->dataPtr->FloatingBody.BuoyancyForce(x);
   wbidbg << "Buoyancy Force at waterplane = " << BuoyancyForce.transpose()
-        << std::endl;
+         << std::endl;
 
   // Compute Buoyancy Force
   gz::math::Vector3d w_FBp(BuoyancyForce(0), BuoyancyForce(1),


### PR DESCRIPTION
Right now, if we want to see debug statements from another plugin, WaveBodyInteractions produces so much output, that it is difficult to see other prints. Also, logging easily fills up disk space in `~/.gz/sim/log`. So, move gzdbg messages for the WaveBodyInteractions plugin behind debug flag.