### PR TITLE
Fix GitHub detected languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.em -linguist-detectable
+*.tst -linguist-detectable
+*.1 -linguist-detectable
+*.3 -linguist-detectable


### PR DESCRIPTION
very minor and pedantic problem... GitHub was labeling our project as primarily SciLab langage due to our bench test `*.tst` data

![image](https://github.com/osrf/mbari_wec_gz/assets/20071132/63e65c02-8298-40a8-928d-9804e5c5362f)

this PR fixes that:

```
$ github-linguist
68.07%  C++
28.85%  Python
2.65%   CMake
0.43%   Shell
```